### PR TITLE
Add schema validation to VRTs

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - rasterio
   - gdal>=3.2
   - tqdm
+  - lxml
 
   - pytest
   - flake8

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
   - numpy
   - gdal
   - matplotlib
+  - lxml

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: variete
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.8
+  - rasterio
+  - numpy
+  - gdal
+  - matplotlib

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
 
         python_with_pkgs = (pythonpkgs.python.withPackages (_: with pythonpkgs; [
           python
+          ipython
           lxml
           rasterio
           gdal

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
 
         python_with_pkgs = (pythonpkgs.python.withPackages (_: with pythonpkgs; [
           python
+          lxml
           rasterio
           gdal
           pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 	{name = "Erik Mannerfelt", email="33550973+erikmannerfelt@users.noreply.github.com"},
 ]
 
-dependencies = ["rasterio", "gdal>=3.2", "numpy>=1.20"]
+dependencies = ["rasterio", "gdal>=3.2", "numpy>=1.20", "lxml"]
 
 [project.urls]
 home = "https://pypi.org/project/variete/"

--- a/src/variete/misc.py
+++ b/src/variete/misc.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
 from typing import Any, Literal, overload
 
+import lxml.etree as ET
 from rasterio import CRS, Affine
 from rasterio.warp import Resampling
 

--- a/src/variete/vraster.py
+++ b/src/variete/vraster.py
@@ -674,12 +674,13 @@ class VRaster:
         for band in self.last.raster_bands:
             if band.nodata is not None:
                 return band.nodata
+        return None
 
     @nodata.setter
     def nodata(self, new_nodata: float | int | None) -> None:
         """Set the first nodata value in the raster."""
         for band in self.last.raster_bands:
-            band.nodata = new_nodata 
+            band.nodata = new_nodata
 
     @overload
     def sample(

--- a/src/variete/vrt/pixel_functions.py
+++ b/src/variete/vrt/pixel_functions.py
@@ -3,8 +3,9 @@ Pixel functions that allow arithmetic and other complex operations.
 """
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
 from typing import Literal
+
+import lxml.etree as ET
 
 from variete import misc
 

--- a/src/variete/vrt/raster_bands.py
+++ b/src/variete/vrt/raster_bands.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import warnings
-import xml.etree.ElementTree as ET
+
+import lxml.etree as ET
 
 from variete import misc
 from variete.vrt.pixel_functions import AnyPixelFunction, pixel_function_from_etree

--- a/src/variete/vrt/sources.py
+++ b/src/variete/vrt/sources.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import copy
 import warnings
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import lxml.etree as ET
 
 from variete import misc
 

--- a/src/variete/vrt/vrt.py
+++ b/src/variete/vrt/vrt.py
@@ -387,11 +387,15 @@ class VRTDataset:
         else:
             y_coords = y_coord
         with self.open_rio() as raster:
-            values = np.fromiter(
-                raster.sample(zip(x_coords, y_coords), indexes=band, masked=masked),
-                dtype=self.raster_bands[0].dtype,
-                count=-1 if not hasattr(x_coords, "__len__") else len(x_coords),  # type: ignore
-            ).ravel()
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", r".*Conversion of an array with ndim > 0 to a scalar is deprecated.*"
+                )  # Should be removed when rasterio fixes this (2023-08-02)
+                values = np.fromiter(
+                    raster.sample(zip(x_coords, y_coords), indexes=band, masked=masked),
+                    dtype=self.raster_bands[0].dtype,
+                    count=-1 if not hasattr(x_coords, "__len__") else len(x_coords),  # type: ignore
+                ).ravel()
             if values.size > 1:
                 return values
             return values[0]

--- a/src/variete/vrt/vrt.py
+++ b/src/variete/vrt/vrt.py
@@ -4,11 +4,11 @@ import copy
 import hashlib
 import tempfile
 import warnings
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Callable, Iterable, Literal, Sequence
 
+import lxml.etree as ET
 import numpy as np
 import numpy.typing as npt
 import rasterio as rio
@@ -97,7 +97,13 @@ def vrt_warp(
     if isinstance(resampling, str):
         resampling = getattr(Resampling, resampling)
 
-    kwargs = {"resampleAlg": misc.resampling_rio_to_gdal(resampling), "multithread": multithread, "format": "VRT", "dstNodata": dst_nodata, "srcNodata": src_nodata}
+    kwargs = {
+        "resampleAlg": misc.resampling_rio_to_gdal(resampling),
+        "multithread": multithread,
+        "format": "VRT",
+        "dstNodata": dst_nodata,
+        "srcNodata": src_nodata,
+    }
 
     # This is strange. Warped pixels that are outside the range of the original raster get assigned to 0
     # Unclear if this can be overridden somehow! It should be dst_nodata or np.nan

--- a/tests/gdalvrt.xsd
+++ b/tests/gdalvrt.xsd
@@ -1,0 +1,609 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/******************************************************************************
+ * $Id$
+ *
+ * Project:  GDAL/OGR
+ * Purpose:  XML Schema for GDAL VRT files.
+ * Author:   Even Rouault, <even dot rouault at spatialys dot com>
+ *
+ **********************************************************************
+ * Copyright (c) 2015, Even Rouault
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="1.0">
+    <xs:element name="VRTDataset">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="SRS" type="SRSType"/>
+                    <xs:element name="GeoTransform" type="xs:string"/>
+                    <xs:element name="GCPList" type="GCPListType"/>
+                    <xs:element name="BlockXSize" type="nonNegativeInteger32"/>
+                    <xs:element name="BlockYSize" type="nonNegativeInteger32"/>
+                    <xs:element name="Metadata" type="MetadataType"/> <!-- may be repeated -->
+                    <xs:element name="VRTRasterBand" type="VRTRasterBandType"/> <!-- may be repeated -->
+                    <xs:element name="MaskBand" type="MaskBandType"/>
+                    <xs:element name="GDALWarpOptions" type="GDALWarpOptionsType"/> <!-- only if subClass="VRTWarpedDataset" -->
+                    <xs:element name="PansharpeningOptions" type="PansharpeningOptionsType"/> <!-- only if subClass="VRTPansharpenedDataset" -->
+                    <xs:element name="Group" type="GroupType"/> <!-- only for multidimensional dataset -->
+                    <xs:element name="OverviewList" type="OverviewListType"/>
+                </xs:choice>
+            </xs:sequence>
+            <xs:attribute name="subClass" type="xs:string"/>
+            <xs:attribute name="rasterXSize" type="nonNegativeInteger32"/>
+            <xs:attribute name="rasterYSize" type="nonNegativeInteger32"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="OverviewListType">
+        <xs:simpleContent>
+            <xs:extension base="integerList">
+                <xs:attribute name="resampling" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="integerList">
+        <xs:list itemType="xs:integer"/>
+    </xs:simpleType>
+
+    <xs:complexType name="SRSType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="dataAxisToSRSAxisMapping" type="xs:string"/>
+                <xs:attribute name="coordinateEpoch" type="xs:float"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="nonNegativeInteger32">
+        <xs:restriction base="xs:nonNegativeInteger">
+            <xs:maxInclusive value="2147483647"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="GCPListType">
+        <xs:sequence>
+            <xs:element name="GCP" type="GCPType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="Projection" type="xs:string"/>
+        <xs:attribute name="dataAxisToSRSAxisMapping" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="GCPType">
+        <xs:attribute name="Id" type="xs:string"/>
+        <xs:attribute name="Info" type="xs:string"/>
+        <xs:attribute name="Pixel" type="xs:double" use="required"/>
+        <xs:attribute name="Line" type="xs:double" use="required"/>
+        <xs:attribute name="X" type="xs:double" use="required"/>
+        <xs:attribute name="Y" type="xs:double" use="required"/>
+        <xs:attribute name="Z" type="xs:double"/>
+        <xs:attribute name="GCPZ" type="xs:double"/> <!-- deprecated -->
+    </xs:complexType>
+
+    <xs:complexType name="MetadataType">
+        <xs:sequence>
+            <!--<xs:choice>-->
+                <!--<xs:element name="MDI" type="MDIType" minOccurs="0" maxOccurs="unbounded"/>-->
+                <xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+            <!--</xs:choice>-->
+        </xs:sequence>
+        <xs:attribute name="domain" type="xs:string"/>
+        <xs:attribute name="format" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="GDALWarpOptionsType">
+        <xs:sequence>
+            <xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="PansharpeningOptionsType">
+        <xs:sequence>
+            <xs:element name="Algorithm" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="AlgorithmOptions" type="AlgorithmOptionsType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="Resampling" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="NumThreads" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="BitDepth" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="NoData" type="NoDataOrNoneType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="SpatialExtentAdjustment" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="PanchroBand" type="PanchroBandType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="SpectralBand" type="SpectralBandType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="NoDataOrNoneType">
+        <xs:union memberTypes="xs:double xs:string" />
+    </xs:simpleType>
+
+    <xs:complexType name="PanchroBandType">
+        <xs:sequence>
+            <xs:element name="SourceFilename" type="SourceFilenameType"/>
+            <xs:element name="SourceBand" type="xs:string"/>  <!-- should be refined into xs:nonNegativeInteger or mask,xs:nonNegativeInteger -->
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="SpectralBandType">
+        <xs:sequence>
+            <xs:element name="SourceFilename" type="SourceFilenameType"/>
+            <xs:element name="SourceBand" type="xs:string"/>  <!-- should be refined into xs:nonNegativeInteger or mask,xs:nonNegativeInteger -->
+        </xs:sequence>
+        <xs:attribute name="dstBand" type="xs:nonNegativeInteger"/>
+    </xs:complexType>
+
+    <xs:complexType name="AlgorithmOptionsType">
+        <xs:sequence>
+            <xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="MDIType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="key" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="VRTRasterBandType">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="Description" type="xs:string"/>
+                <xs:element name="UnitType" type="xs:string"/>
+                <xs:element name="Offset" type="xs:double"/>
+                <xs:element name="Scale" type="xs:double"/>
+                <xs:element name="CategoryNames" type="CategoryNamesType"/>
+                <xs:element name="ColorTable" type="ColorTableType"/>
+                <xs:element name="GDALRasterAttributeTable" type="GDALRasterAttributeTableType"/>
+                <xs:element name="NoDataValue" type="DoubleOrNanType"/>
+                <xs:element name="NodataValue" type="xs:double"/> <!-- typo: deprecated -->
+                <xs:element name="HideNoDataValue" type="ZeroOrOne"/>
+                <xs:element name="Metadata" type="MetadataType"/>
+                <xs:element name="ColorInterp" type="ColorInterpType"/>
+                <xs:element name="Overview" type="OverviewType"/>
+                <xs:element name="MaskBand" type="MaskBandType"/>
+                <xs:element name="Histograms" type="HistogramsType"/>
+
+                <!-- for a VRTSourcedRasterBand. Each element may be repeated -->
+                <xs:element name="SimpleSource" type="SimpleSourceType"/>
+                <xs:element name="ComplexSource" type="ComplexSourceType"/>
+                <xs:element name="AveragedSource" type="SimpleSourceType"/>
+                <xs:element name="KernelFilteredSource" type="KernelFilteredSourceType"/>
+
+                <!-- for a VRTDerivedRasterBand -->
+                <xs:element name="PixelFunctionType" type="xs:string"/>
+                <xs:element name="SourceTransferType" type="DataTypeType"/>
+                <xs:element name="PixelFunctionLanguage" type="xs:string"/>
+                <xs:element name="PixelFunctionCode" type="xs:string"/>
+                <xs:element name="PixelFunctionArguments">
+                    <xs:complexType>
+                        <xs:anyAttribute processContents="lax"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="BufferRadius" type="xs:nonNegativeInteger"/>
+                <xs:element name="SkipNonContributingSources" type="xs:boolean"/>
+
+                <!-- for a VRTRawRasterBand -->
+                <xs:element name="SourceFilename" type="SourceFilenameType"/>
+                <xs:element name="ImageOffset" type="xs:integer"/>
+                <xs:element name="PixelOffset" type="xs:integer"/>
+                <xs:element name="LineOffset" type="xs:integer"/>
+                <xs:element name="ByteOrder" type="xs:string"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="dataType" type="DataTypeType"/>
+        <xs:attribute name="band" type="xs:unsignedInt"/>
+        <xs:attribute name="blockXSize" type="nonNegativeInteger32"/>
+        <xs:attribute name="blockYSize" type="nonNegativeInteger32"/>
+        <xs:attribute name="subClass" type="VRTRasterBandSubClassType"/>
+    </xs:complexType>
+
+    <xs:simpleType name="ZeroOrOne">
+        <xs:restriction base="xs:integer">
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="VRTRasterBandSubClassType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="VRTWarpedRasterBand"/>
+            <xs:enumeration value="VRTDerivedRasterBand"/>
+            <xs:enumeration value="VRTRawRasterBand"/>
+            <xs:enumeration value="VRTPansharpenedRasterBand"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="MaskBandType">
+        <xs:sequence minOccurs="1" maxOccurs="1">
+            <xs:element name="VRTRasterBand" type="VRTRasterBandType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="HistogramsType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="HistItem" type="HistItemType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="HistItemType">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="HistMin" type="xs:double"/>
+                <xs:element name="HistMax" type="xs:double"/>
+                <xs:element name="BucketCount" type="xs:integer"/>
+                <xs:element name="IncludeOutOfRange" type="ZeroOrOne"/>
+                <xs:element name="Approximate" type="ZeroOrOne"/>
+                <xs:element name="HistCounts" type="xs:string"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="CategoryNamesType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="Category" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ColorTableType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="Entry" type="ColorTableEntryType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="GDALRasterAttributeTableType">
+        <xs:sequence>
+            <xs:element name="FieldDefn" type="FieldDefnType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="Row" type="RowType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="FieldDefnType">
+        <xs:sequence>
+            <xs:element name="Name" type="xs:string"/>
+            <xs:element name="Type" type="xs:unsignedInt"/>
+            <xs:element name="Usage" type="xs:unsignedInt"/>
+        </xs:sequence>
+        <xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="RowType">
+        <xs:sequence>
+            <xs:element name="F" type="xs:anyType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="index" type="xs:unsignedInt" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="OverviewType">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="SourceFilename" type="SourceFilenameType"/>
+                <xs:element name="SourceBand" type="xs:string"/>  <!-- should be refined into xs:nonNegativeInteger or mask,xs:nonNegativeInteger -->
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ColorTableEntryType">
+        <xs:attribute name="c1" type="xs:unsignedInt" use="required"/>
+        <xs:attribute name="c2" type="xs:unsignedInt" use="required" />
+        <xs:attribute name="c3" type="xs:unsignedInt" use="required" />
+        <xs:attribute name="c4" type="xs:unsignedInt" />
+    </xs:complexType>
+
+    <xs:simpleType name="DataTypeType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Byte"/>
+            <xs:enumeration value="UInt16"/>
+            <xs:enumeration value="Int16"/>
+            <xs:enumeration value="UInt32"/>
+            <xs:enumeration value="Int32"/>
+            <xs:enumeration value="UInt64"/>
+            <xs:enumeration value="Int64"/>
+            <xs:enumeration value="Float32"/>
+            <xs:enumeration value="Float64"/>
+            <xs:enumeration value="CInt16"/>
+            <xs:enumeration value="CInt32"/>
+            <xs:enumeration value="CFloat32"/>
+            <xs:enumeration value="CFloat64"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="ColorInterpType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Gray"/>
+            <xs:enumeration value="Palette"/>
+            <xs:enumeration value="Red"/>
+            <xs:enumeration value="Green"/>
+            <xs:enumeration value="Blue"/>
+            <xs:enumeration value="Alpha"/>
+            <xs:enumeration value="Hue"/>
+            <xs:enumeration value="Saturation"/>
+            <xs:enumeration value="Lightness"/>
+            <xs:enumeration value="Cyan"/>
+            <xs:enumeration value="Magenta"/>
+            <xs:enumeration value="Yellow"/>
+            <xs:enumeration value="Black"/>
+            <xs:enumeration value="YCbCr_Y"/>
+            <xs:enumeration value="YCbCr_Cb"/>
+            <xs:enumeration value="YCbCr_Cr"/>
+            <xs:enumeration value="Undefined"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:group name="SimpleSourceElementsGroup">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="SourceFilename" type="SourceFilenameType"/>
+                <xs:element name="OpenOptions" type="OpenOptionsType"/>
+                <xs:element name="SourceBand" type="xs:string"/>  <!-- should be refined into xs:nonNegativeInteger or mask,xs:nonNegativeInteger -->
+                <xs:element name="SourceProperties" type="SourcePropertiesType"/>
+                <xs:element name="SrcRect" type="RectType"/>
+                <xs:element name="DstRect" type="RectType"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+
+    <xs:complexType name="OpenOptionsType">
+        <xs:sequence>
+            <xs:element name="OOI" type="OOIType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="OOIType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="key" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="SimpleSourceType">
+        <xs:group ref="SimpleSourceElementsGroup"/>
+        <xs:attribute name="resampling" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:group name="ComplexSourceElementsGroup">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="SimpleSourceElementsGroup"/>
+                <xs:element name="ScaleOffset" type="xs:double"/>
+                <xs:element name="ScaleRatio" type="xs:double"/>
+                <xs:element name="ColorTableComponent" type="xs:nonNegativeInteger"/>
+                <xs:element name="Exponent" type="xs:double"/>
+                <xs:element name="SrcMin" type="xs:double"/>
+                <xs:element name="SrcMax" type="xs:double"/>
+                <xs:element name="DstMin" type="xs:double"/>
+                <xs:element name="DstMax" type="xs:double"/>
+                <xs:element name="NODATA" type="DoubleOrNanType"/> <!-- NODATA and UseMaskBand are mutually exclusive -->
+                <xs:element name="UseMaskBand" type="xs:boolean"/> <!-- NODATA and UseMaskBand are mutually exclusive -->
+                <xs:element name="LUT" type="xs:string"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+
+    <xs:complexType name="ComplexSourceType">
+        <xs:group ref="ComplexSourceElementsGroup"/>
+        <xs:attribute name="resampling" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="KernelFilteredSourceType">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="ComplexSourceElementsGroup"/>
+                <xs:element name="Kernel" type="KernelType"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="resampling" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="KernelType">
+        <xs:all>
+            <xs:element name="Size" type="xs:nonNegativeInteger"/>
+            <xs:element name="Coefs" type="xs:string"/>
+        </xs:all>
+
+        <xs:attribute name="normalized" type="ZeroOrOne"/>
+    </xs:complexType>
+
+    <xs:simpleType name="DoubleOrNanType">
+        <xs:union memberTypes="xs:double NANType" />
+    </xs:simpleType>
+
+    <xs:simpleType name="NANType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="nan"/>
+            <xs:enumeration value="NAN"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="SourceFilenameType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="relativeToVRT" type="ZeroOrOne" />
+                <xs:attribute name="relativetoVRT" type="ZeroOrOne" /> <!-- typo: deprecated -->
+                <xs:attribute name="shared" type="OGRBooleanType"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:simpleType name="OGRBooleanType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="1"/>
+            <xs:enumeration value="0"/>
+            <xs:enumeration value="ON"/>
+            <xs:enumeration value="OFF"/>
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+            <xs:enumeration value="YES"/>
+            <xs:enumeration value="NO"/>
+            <xs:enumeration value="yes"/>
+            <xs:enumeration value="no"/>
+            <xs:enumeration value="TRUE"/>
+            <xs:enumeration value="FALSE"/>
+            <xs:enumeration value="true"/>
+            <xs:enumeration value="false"/>
+            <xs:enumeration value="True"/>
+            <xs:enumeration value="False"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="SourcePropertiesType">
+        <xs:attribute name="RasterXSize" type="nonNegativeInteger32" />
+        <xs:attribute name="RasterYSize" type="nonNegativeInteger32" />
+        <xs:attribute name="DataType" type="DataTypeType" />
+        <xs:attribute name="BlockXSize" type="nonNegativeInteger32" />
+        <xs:attribute name="BlockYSize" type="nonNegativeInteger32" />
+    </xs:complexType>
+
+    <xs:complexType name="RectType">
+        <xs:attribute name="xOff" type="xs:double" />
+        <xs:attribute name="yOff" type="xs:double" />
+        <xs:attribute name="xSize" type="nonNegativeDouble" />
+        <xs:attribute name="ySize" type="nonNegativeDouble" />
+    </xs:complexType>
+
+    <xs:simpleType name="nonNegativeDouble">
+        <xs:restriction base="xs:double">
+            <xs:minExclusive value="0.0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="GroupType">
+        <xs:sequence>
+            <xs:element name="Dimension" type="DimensionType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="Attribute" type="AttributeType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="Array" type="ArrayType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="Group" type="GroupType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="ArrayType">
+        <xs:sequence>
+            <xs:element name="DataType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:sequence>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="Dimension" type="DimensionType"/>
+                        <xs:element name="DimensionRef" type="DimensionRefType"/>
+                    </xs:choice>
+                </xs:sequence>
+            <xs:element name="SRS" type="SRSType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="Unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="NoDataValue" type="DoubleOrNanType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="Offset" type="xs:double" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="Scale" type="xs:double" minOccurs="0" maxOccurs="1"/>
+            <xs:choice>
+                <xs:element name="RegularlySpacedValues" type="RegularlySpacedValuesType" minOccurs="0" maxOccurs="1"/>
+                <xs:sequence>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="ConstantValue" type="ConstantValueType"/>
+                        <xs:element name="InlineValues" type="InlineValuesType"/>
+                        <xs:element name="InlineValuesWithValueElement" type="InlineValuesWithValueElementType"/>
+                        <xs:element name="Source" type="SourceType"/>
+                    </xs:choice>
+                </xs:sequence>
+            </xs:choice>
+            <xs:element name="Attribute" type="AttributeType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="RegularlySpacedValuesType">
+        <xs:attribute name="start" type="xs:double" use="required"/>
+        <xs:attribute name="increment" type="xs:double" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="ConstantValueType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="offset" type="xs:string"/>
+                <xs:attribute name="count" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="InlineValuesType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="offset" type="xs:string"/>
+                <xs:attribute name="count" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="InlineValuesWithValueElementType">
+        <xs:sequence>
+            <xs:element name="Value" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="offset" type="xs:string"/>
+        <xs:attribute name="count" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="SourceType">
+        <xs:sequence>
+            <xs:element name="SourceFilename" type="SourceFilenameType"/>
+            <xs:choice>
+                <xs:element name="SourceArray" type="xs:string"/>
+                <xs:element name="SourceBand" type="xs:string"/>
+            </xs:choice>
+            <xs:element name="SourceTranspose" type="xs:string" minOccurs="0"/>
+            <xs:element name="SourceView" type="xs:string" minOccurs="0"/>
+            <xs:element name="SourceSlab" type="SourceSlabType" minOccurs="0"/>
+            <xs:element name="DestSlab" type="DestSlabType" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="SourceSlabType">
+        <xs:sequence/>
+        <xs:attribute name="offset" type="xs:string"/>
+        <xs:attribute name="count" type="xs:string"/>
+        <xs:attribute name="step" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="DestSlabType">
+        <xs:sequence/>
+        <xs:attribute name="offset" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="AttributeType">
+        <xs:sequence>
+            <xs:element name="DataType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="Value" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="DimensionType">
+        <xs:sequence/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="type" type="xs:string"/>
+        <xs:attribute name="direction" type="xs:string"/>
+        <xs:attribute name="size" type="xs:nonNegativeInteger" use="required"/>
+        <xs:attribute name="indexingVariable" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="DimensionRefType">
+        <xs:sequence/>
+        <xs:attribute name="ref" type="xs:string" use="required"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/tests/test_vraster.py
+++ b/tests/test_vraster.py
@@ -498,7 +498,7 @@ def flatten_list(in_list: list[Any]) -> list[Any]:
         + [
             pytest.param(param, marks=pytest.mark.xfail)
             for param in flatten_list(
-                [["float16"], ["complex32"]]  # This is not supported by GDAL  # This is not supported by numpy
+                [["float16"], ["complex32"]]  # float16 is not supported by GDAL  # complex32 is not supported by numpy
             )
         ]
     ),

--- a/tests/test_vraster.py
+++ b/tests/test_vraster.py
@@ -1,6 +1,8 @@
 import tempfile
 from pathlib import Path
+from typing import Any
 
+import lxml.etree as ET
 import numpy as np
 import pytest
 import rasterio as rio
@@ -429,7 +431,11 @@ def test_different_transforms_and_shapes() -> None:
 
         test_raster_path_b = Path(temp_dir).joinpath("test_b.tif")
         # Make raster which is both slightly smaller and is shifted 4 pixels east
-        make_test_raster(test_raster_path_b, assign_values=four_arr[:49, :], transform = rio.transform.from_origin(5e5 + 40, 8.7e6, 10, 10))
+        make_test_raster(
+            test_raster_path_b,
+            assign_values=four_arr[:49, :],
+            transform=rio.transform.from_origin(5e5 + 40, 8.7e6, 10, 10),
+        )
 
         vrst_a = VRaster.load_file(test_raster_path_a)
         vrst_b = VRaster.load_file(test_raster_path_b)
@@ -443,15 +449,80 @@ def test_different_transforms_and_shapes() -> None:
 
         with pytest.raises(AssertionError, match="Shapes must be the same.*"):
             vrst_b_correct_transform - vrst_a
-            
 
         # Warp the raster and then subtract, which should work
         vrst_b_warped = vrst_b.warp(vrst_a, resampling="nearest").replace_nodata(np.nan)
         diff = vrst_b_warped - vrst_a
 
         # Validate that the difference is as expected
-        assert not np.all(diff.read(1) == 2.)
+        assert not np.all(diff.read(1) == 2.0)
         assert np.all(np.isnan(diff.sample_rowcol(0, list(range(4)))))
-        assert np.all(diff.sample_rowcol(0, list(range(4, diff.shape[0]))) == 2.)
+        assert np.all(diff.sample_rowcol(0, list(range(4, diff.shape[0]))) == 2.0)
 
-    
+
+def load_vrt_schema() -> ET.XMLSchema:
+    with open(Path(__file__).with_name("gdalvrt.xsd"), "rb") as infile:
+        return ET.XMLSchema(ET.fromstring(infile.read()))
+
+
+def flatten_list(in_list: list[Any]) -> list[Any]:
+    new_list = []
+    for item in in_list:
+        if isinstance(item, list):
+            new_list += flatten_list(item)
+        else:
+            new_list.append(item)
+    return new_list
+
+
+@pytest.mark.parametrize(
+    "crs", [32633, pytest.param(4326, marks=pytest.mark.skip)]
+)  # 4326 is skipped because it fails on warping. Opening an issue (2023-08-01)
+@pytest.mark.parametrize("nodata", [None, 1.0, 99])
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        ["uint8"]
+        + [f"int{bits}" for bits in [8, 16, 32]]
+        + [f"float{bits}" for bits in [32, 64]]
+        + [
+            pytest.param(param, marks=pytest.mark.skip)
+            for param in flatten_list(
+                [
+                    ["int64"],
+                    [f"uint{bits}" for bits in [16, 32, 64]],
+                    [f"complex{bits}" for bits in [64, 128]],
+                ]
+            )
+        ]
+        + [
+            pytest.param(param, marks=pytest.mark.xfail)
+            for param in flatten_list(
+                [["float16"], ["complex32"]]  # This is not supported by GDAL  # This is not supported by numpy
+            )
+        ]
+    ),
+)
+def test_vrt_schema(crs: int, nodata: int | float | None, dtype: str) -> None:
+    schema = load_vrt_schema()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        test_raster_path = Path(temp_dir).joinpath("test.tif")
+        make_test_raster(test_raster_path, crs=crs, nodata=nodata, dtype=dtype)
+
+        vrst = VRaster.load_file(test_raster_path)
+
+        # Test addition (creating a nested VRT)
+        vrst += 1
+        # Test inversion (another op., creating a nested VRT)
+        vrst = vrst.inverse()
+
+        # Test warping (creating a nested warped VRT)
+        vrst = vrst.warp(crs=rio.CRS.from_epsg(3006))
+
+        vrt_paths = vrst.save_vrt(Path(temp_dir).joinpath("a.vrt"))
+
+        # Validate all VRTs with the schema
+        for filepath in vrt_paths:
+            with open(filepath, "rb") as infile:
+                schema.assertValid(ET.fromstring(infile.read()))

--- a/tests/test_vraster.py
+++ b/tests/test_vraster.py
@@ -483,7 +483,7 @@ def flatten_list(in_list: list[Any]) -> list[Any]:
     "dtype",
     (
         ["uint8"]
-        + [f"int{bits}" for bits in [8, 16, 32]]
+        + [f"int{bits}" for bits in [16, 32]]
         + [f"float{bits}" for bits in [32, 64]]
         + [
             pytest.param(param, marks=pytest.mark.skip)

--- a/tests/test_vrt.py
+++ b/tests/test_vrt.py
@@ -20,9 +20,12 @@ def make_test_raster(
     mean_val: int | float | None = None,
     assign_values: npt.NDArray[Any] | None = None,
     dtype: str = "float32",
-    transform = rio.transform.from_origin(5e5, 8.7e6, 10, 10)
+    transform: rio.transform.Affine | None = None,
+    crs: int = 32633,
 ) -> dict[str, Any]:
-    crs = rio.crs.CRS.from_epsg(32633)
+    crs = rio.crs.CRS.from_epsg(crs)
+    if transform is None:
+        transform = rio.transform.from_origin(5e5, 8.7e6, 10, 10)
 
     if assign_values is not None:
         data = assign_values
@@ -208,7 +211,7 @@ def test_vrt_warp(test_case: dict[str, object]) -> None:
         result = test_case.pop("result")
 
         if result != "pass":
-            with pytest.raises(ValueError, match=result):
+            with pytest.raises(ValueError, match=result):  # type: ignore
                 variete.vrt.vrt.vrt_warp(test_vrt_path, test_raster_path, **test_case)  # type: ignore
             return
         else:


### PR DESCRIPTION
This PR adds validation for VRTs using the official GDAL VRT schema (see #3 for a link). This required an XML schema validation package, and `lxml` has that, while also supposedly being a faster drop-in replacement for the builtin `xml` module. I tried changing all `xml` imports to `lxml` and all tests passed, so I assume everything is slightly faster now.

The PR got a bit messy as some files didn't conform to the pre-commit standards. I fixed all of that, but it now means the amount of changed lines is huge.

Testing is in the `tests/test_vraster.py` file instead of `tests/test_vrt.py` even though the latter would have made a bit more sense. The reason is that `VRaster`s allow for a fast and clean creation of multiple (nested) VRTs, making the tests more complete while being easier to read. This was mostly motivated by the fact that warped VRTs are quite difficult to create without making a `VRaster`.

A few issues came up:
- #5: Some dtypes are not supported when they should be
- #6: I found warp issues on accident when trying to make a good test coverage.

The power of schema validation is probably not yet complete in this PR; I simply try out a few of the many functionalities, so the test suite should be expanded to try as many cases as possible.

Closes #3

## Future considerations
- Expand the test cases to cover even more
- Check whether it's worth dynamically downloading the VRT schema from the latest GDAL branch, and if multiple GDAL versions should be tested. Now it's copied (with original credits in the file) into this repo to make offline testing easier, but this will get outdated eventually. The latest commit on this file as of today (2023-08-02) was seven months ago. Thus, development is still "active", so this should be considered.
- Potentially add schema validation as an (optional?) step when loading a VRT. Either it's using the schema, or the loader is smart enough to either fix or tell what's wrong.