### PR TITLE
Fix incorrect dtype conversions and add missing ones

### DIFF
--- a/src/variete/misc.py
+++ b/src/variete/misc.py
@@ -45,11 +45,14 @@ def get_dtype_gdal_to_numpy() -> dict[str, str]:
 
     for number, bits in [("float", [32, 64]), ("int", [16, 32, 64])]:
         for bit in bits:
-            dtype = f"{number}{bit}".capitalize()
+            dtype = f"{number}{bit}"
             dtypes[dtype.capitalize()] = dtype
 
             if number == "int":
                 dtypes[f"UInt{bit}"] = f"uint{bit}"
+
+    for bit in [32, 64]:
+        dtypes[f"CFloat{bit}"] = f"complex{bit * 2}"
 
     return dtypes
 

--- a/src/variete/misc.py
+++ b/src/variete/misc.py
@@ -42,11 +42,14 @@ def resampling_rio_to_gdal(resampling: Resampling) -> str:
 
 def get_dtype_gdal_to_numpy() -> dict[str, str]:
     dtypes = {"Byte": "uint8"}
-    for dtype in ["float32", "float64", "int16", "int32", "int64"]:
-        dtypes[dtype.capitalize()] = dtype
 
-    for gdal_dtype in ["UInt16", "UInt32"]:
-        dtypes[gdal_dtype] = gdal_dtype.lower()
+    for number, bits in [("float", [32, 64]), ("int", [16, 32, 64])]:
+        for bit in bits:
+            dtype = f"{number}{bit}".capitalize()
+            dtypes[dtype.capitalize()] = dtype
+
+            if number == "int":
+                dtypes[f"UInt{bit}"] = f"uint{bit}"
 
     return dtypes
 

--- a/src/variete/misc.py
+++ b/src/variete/misc.py
@@ -42,7 +42,7 @@ def resampling_rio_to_gdal(resampling: Resampling) -> str:
 
 def get_dtype_gdal_to_numpy() -> dict[str, str]:
     dtypes = {"Byte": "uint8"}
-    for dtype in ["float32", "float64", "int16", "int32"]:
+    for dtype in ["float32", "float64", "int16", "int32", "int64"]:
         dtypes[dtype.capitalize()] = dtype
 
     for gdal_dtype in ["UInt16", "UInt32"]:

--- a/src/variete/vrt/sources.py
+++ b/src/variete/vrt/sources.py
@@ -28,7 +28,7 @@ class SourceProperties:
             {
                 "RasterXSize": str(self.shape[1]),
                 "RasterYSize": str(self.shape[0]),
-                "DataType": self.dtype.capitalize(),
+                "DataType": misc.dtype_numpy_to_gdal(self.dtype),
                 "BlockYSize": str(self.block_size[0]),
                 "BlockXSize": str(self.block_size[1]),
             },
@@ -37,7 +37,7 @@ class SourceProperties:
     @classmethod
     def from_etree(cls, elem: ET.Element) -> SourceProperties:
         shape = (int(elem.get("RasterYSize", 0)), int(elem.get("RasterXSize", 0)))
-        dtype = elem.get("DataType", "Byte").lower()
+        dtype = misc.dtype_gdal_to_numpy(elem.get("DataType", "Byte"))
         block_size = (int(elem.get("BlockYSize", "1")), int(elem.get("BlockXSize", "1")))
 
         return cls(shape=shape, dtype=dtype, block_size=block_size)

--- a/tests/test_vraster.py
+++ b/tests/test_vraster.py
@@ -483,14 +483,13 @@ def flatten_list(in_list: list[Any]) -> list[Any]:
     "dtype",
     (
         ["uint8"]
-        + [f"int{bits}" for bits in [16, 32]]
+        + [f"int{bits}" for bits in [16, 32, 64]]
         + [f"float{bits}" for bits in [32, 64]]
+        + [f"uint{bits}" for bits in [16, 32, 64]]
         + [
             pytest.param(param, marks=pytest.mark.skip)
             for param in flatten_list(
                 [
-                    ["int64"],
-                    [f"uint{bits}" for bits in [16, 32, 64]],
                     [f"complex{bits}" for bits in [64, 128]],
                 ]
             )

--- a/tests/test_vraster.py
+++ b/tests/test_vraster.py
@@ -486,14 +486,7 @@ def flatten_list(in_list: list[Any]) -> list[Any]:
         + [f"int{bits}" for bits in [16, 32, 64]]
         + [f"float{bits}" for bits in [32, 64]]
         + [f"uint{bits}" for bits in [16, 32, 64]]
-        + [
-            pytest.param(param, marks=pytest.mark.skip)
-            for param in flatten_list(
-                [
-                    [f"complex{bits}" for bits in [64, 128]],
-                ]
-            )
-        ]
+        + [f"complex{bits}" for bits in [64, 128]]
         + [
             pytest.param(param, marks=pytest.mark.xfail)
             for param in flatten_list(


### PR DESCRIPTION
This PR fixes the problems found in #5.

- All `Uint*` -> `UInt*` issues are fixed.
- Int64 now works.
- Complex floats are now supported.

A big issue remains with GDAL's `CInt16` and `CInt32` as they have no numpy counterpart, and vice versa with `float16`. The `float16` issue is probably easiest to either silently convert to 32 or error out descriptively. For `CInt*`, however, there needs to be further thought.

Closes #5 